### PR TITLE
Bump zknotes & jobs & login

### DIFF
--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ uuid = { version = "1.7", features = ["serde", "v4", "fast-rng"] }
 
 zknotes-server-lib = { path = "../../zknotes/server-lib" }
 time = { version = "0.3.36", features = ["formatting"] }
+girlboss = "0.3.0"

--- a/tauri/src-tauri/src/commands.rs
+++ b/tauri/src-tauri/src/commands.rs
@@ -17,7 +17,6 @@ use zknotes_server_lib::{sqldata, UserResponse, UserResponseMessage};
 
 pub struct ZkState {
   pub state: Arc<RwLock<zknotes_server_lib::state::State>>,
-  pub uid: Mutex<Option<i64>>,
 }
 
 #[tauri::command]
@@ -185,7 +184,7 @@ pub fn fileresp_helper(
 }
 
 #[tauri::command]
-pub fn zimsg(state: State<ZkState>, msg: PrivateMessage) -> PrivateTimedData {
+pub async fn zimsg(state: State<'_, ZkState>, msg: PrivateMessage) -> Result<PrivateTimedData, ()> {
   // gonna need config obj, uid.
   // uid could be passed from elm maybe.
 
@@ -230,7 +229,7 @@ pub fn zimsg(state: State<ZkState>, msg: PrivateMessage) -> PrivateTimedData {
     }
   });
 
-  res.join().unwrap()
+  Ok(res.join().unwrap())
 }
 
 #[tauri::command]

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -23,7 +23,6 @@ pub fn run() {
   tauri::Builder::default()
     .manage(ZkState {
       state: Arc::new(RwLock::new(state)),
-      uid: Mutex::new(None),
     })
     .setup(|app| {
       // println!("dbpath: {:?}", dbpath);
@@ -73,12 +72,9 @@ pub fn run() {
           let cc = state.config.clone();
 
           // spawn the web server in a separate thread.
-          let _handler = thread::spawn(|| {
-            println!("meh here");
-            match err_main(Some(cc), Some(logpath)) {
-              Err(e) => println!("error: {:?}", e),
-              Ok(_) => (),
-            }
+          let _handler = thread::spawn(|| match err_main(Some(cc), Some(logpath)) {
+            Err(e) => println!("error: {:?}", e),
+            Ok(_) => (),
           });
         }
         Err(_) => (),

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
 mod commands;
 use commands::{greet, login_data, pimsg, uimsg, zimsg, ZkState};
 use girlboss::Girlboss;
@@ -12,6 +11,7 @@ use zknotes_server_lib::state::State;
 
 // THIS IS THE ONE FOR ANDROID!
 
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let gb: Girlboss<JobId> = Girlboss::new();
   let state = State {

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -1,24 +1,34 @@
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
 mod commands;
 use commands::{greet, login_data, pimsg, uimsg, zimsg, ZkState};
-use std::sync::Mutex;
+use girlboss::Girlboss;
+use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::SystemTime;
 use tauri::Manager;
 use zknotes_server_lib::err_main;
+use zknotes_server_lib::jobs::JobId;
+use zknotes_server_lib::state::State;
 
 // THIS IS THE ONE FOR ANDROID!
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+  let gb: Girlboss<JobId> = Girlboss::new();
+  let state = State {
+    config: zknotes_server_lib::defcon(),
+    girlboss: gb,
+    jobcounter: { RwLock::new(0 as i64) },
+  };
+
   tauri::Builder::default()
     .manage(ZkState {
-      config: Mutex::new(zknotes_server_lib::defcon()),
+      state: Arc::new(RwLock::new(state)),
       uid: Mutex::new(None),
     })
     .setup(|app| {
       // println!("dbpath: {:?}", dbpath);
-      match app.state::<ZkState>().config.lock() {
-        Ok(mut config) => {
+      match app.state::<ZkState>().state.write() {
+        Ok(mut state) => {
           // let datapath = app.path().data_dir().unwrap();
           let datapath = app.path().document_dir().unwrap();
           let mut dbpath = datapath.clone();
@@ -39,28 +49,28 @@ pub fn run() {
 
           println!("logpath {:?}", logpath);
 
-          config.orgauth_config.db = dbpath;
-          config.createdirs = true;
-          config.file_path = filepath;
-          config.file_tmp_path = temppath;
-          config.orgauth_config.open_registration = true;
+          state.config.orgauth_config.db = dbpath;
+          state.config.createdirs = true;
+          state.config.file_path = filepath;
+          state.config.file_tmp_path = temppath;
+          state.config.orgauth_config.open_registration = true;
 
           zknotes_server_lib::sqldata::dbinit(
-            config.orgauth_config.db.as_path(),
-            config.orgauth_config.login_token_expiration_ms,
+            state.config.orgauth_config.db.as_path(),
+            state.config.orgauth_config.login_token_expiration_ms,
           )?;
 
           // verify/create file directories.
-          if config.createdirs {
-            if !std::path::Path::exists(&config.file_tmp_path) {
-              std::fs::create_dir_all(&config.file_tmp_path)?
+          if state.config.createdirs {
+            if !std::path::Path::exists(&state.config.file_tmp_path) {
+              std::fs::create_dir_all(&state.config.file_tmp_path)?
             }
-            if !std::path::Path::exists(&config.file_path) {
-              std::fs::create_dir_all(&config.file_path)?
+            if !std::path::Path::exists(&state.config.file_path) {
+              std::fs::create_dir_all(&state.config.file_path)?
             }
           }
 
-          let cc = config.clone();
+          let cc = state.config.clone();
 
           // spawn the web server in a separate thread.
           let _handler = thread::spawn(|| {

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -48,7 +48,6 @@ fn main() {
   tauri::Builder::default()
     .manage(ZkState {
       state: Arc::new(RwLock::new(state)),
-      uid: Mutex::new(None),
     })
     .setup(|app| {
       // println!("dbpath: {:?}", dbpath);
@@ -96,12 +95,9 @@ fn main() {
 
           let cc = state.config.clone();
 
-          let _handler = thread::spawn(|| {
-            println!("meh here");
-            match err_main(Some(cc), Some(logpath)) {
-              Err(e) => println!("error: {:?}", e),
-              Ok(_) => (),
-            }
+          let _handler = thread::spawn(|| match err_main(Some(cc), Some(logpath)) {
+            Err(e) => println!("error: {:?}", e),
+            Ok(_) => (),
           });
         }
         Err(_) => (),

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1,8 +1,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use girlboss::Girlboss;
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::{sync::Mutex, time::SystemTime};
 use zknotes_server_lib::err_main;
+use zknotes_server_lib::jobs::JobId;
+use zknotes_server_lib::state::State;
 mod commands;
 use commands::{greet, login_data, pimsg, uimsg, zimsg, ZkState};
 use tauri::Manager;
@@ -34,15 +38,22 @@ fn main() {
   //   Ok(config)
   // })();
 
+  let gb: Girlboss<JobId> = Girlboss::new();
+  let state = State {
+    config: zknotes_server_lib::defcon(),
+    girlboss: gb,
+    jobcounter: { RwLock::new(0 as i64) },
+  };
+
   tauri::Builder::default()
     .manage(ZkState {
-      config: Mutex::new(zknotes_server_lib::defcon()),
-      uid: None.into(),
+      state: Arc::new(RwLock::new(state)),
+      uid: Mutex::new(None),
     })
     .setup(|app| {
       // println!("dbpath: {:?}", dbpath);
-      match app.state::<ZkState>().config.lock() {
-        Ok(mut config) => {
+      match app.state::<ZkState>().state.write() {
+        Ok(mut state) => {
           let datapath = app.path().data_dir().unwrap();
           let mut dbpath = datapath.clone();
           dbpath.push("zknotes.db");
@@ -62,28 +73,28 @@ fn main() {
 
           println!("logpath {:?}", logpath);
 
-          config.orgauth_config.db = dbpath;
-          config.createdirs = true;
-          config.file_path = filepath;
-          config.file_tmp_path = temppath;
-          config.orgauth_config.open_registration = true;
+          state.config.orgauth_config.db = dbpath;
+          state.config.createdirs = true;
+          state.config.file_path = filepath;
+          state.config.file_tmp_path = temppath;
+          state.config.orgauth_config.open_registration = true;
 
           zknotes_server_lib::sqldata::dbinit(
-            config.orgauth_config.db.as_path(),
-            config.orgauth_config.login_token_expiration_ms,
+            state.config.orgauth_config.db.as_path(),
+            state.config.orgauth_config.login_token_expiration_ms,
           )?;
 
           // verify/create file directories.
-          if config.createdirs {
-            if !std::path::Path::exists(&config.file_tmp_path) {
-              std::fs::create_dir_all(&config.file_tmp_path)?
+          if state.config.createdirs {
+            if !std::path::Path::exists(&state.config.file_tmp_path) {
+              std::fs::create_dir_all(&state.config.file_tmp_path)?
             }
-            if !std::path::Path::exists(&config.file_path) {
-              std::fs::create_dir_all(&config.file_path)?
+            if !std::path::Path::exists(&state.config.file_path) {
+              std::fs::create_dir_all(&state.config.file_path)?
             }
           }
 
-          let cc = config.clone();
+          let cc = state.config.clone();
 
           let _handler = thread::spawn(|| {
             println!("meh here");


### PR DESCRIPTION
store uid in the single_value table instead of login-data; revamp zimsg handler to work better with job manager.  clean up error handling in zimsg and uimsg.  